### PR TITLE
Use only os_build & arch_build settings for cross-compiling use cases (e.g. building iOS shaders on macOS), git shallow clone

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -4,14 +4,14 @@ import os
 class NicegrafShadercConan(ConanFile):
     name = "nicegraf-shaderc"
     short_paths = True  #windows MAX_PATH(260) limitation fix
-    version = "0.1"
+    version = "0.2"
     license = "MIT"
     author = "<Bagrat Dabaghyan> <dbagrat@gmail.com>"
     url = "https://github.com/dBagrat/conan-nicegraf-shaderc.git"
     homepage = "https://github.com/nicebyte/nicegraf-shaderc"
     description = "nicegraf-shaderc is a command-line tool that transforms HLSL code into shaders for various graphics APIs"
     topics = ("shader compiler", "hlsl", "glsl", "metal")
-    settings = "os_build", "arch_build", "os", "arch", "compiler", "build_type"
+    settings = "os_build", "arch_build", "arch", "compiler"
     options = {"shared": [True, False]}
     default_options = "shared=False"
     generators = "cmake"
@@ -19,19 +19,21 @@ class NicegrafShadercConan(ConanFile):
 
     def source(self):
         git = tools.Git()
-        git.clone("https://github.com/nicebyte/nicegraf-shaderc.git", "master")
+        git.clone("https://github.com/nicebyte/nicegraf-shaderc.git", "master", shallow=True)
         git.checkout("fcf1965e98a9f841fa60297f0a1a18e13e9e88c0")
 
     def configure(self):
         del self.settings.compiler.runtime
-        self.settings.arch = self.settings.arch_build
-        self.settings.os = self.settings.os_build
-        self.settings.build_type = "Release"
 
     def build(self):
-        cmake = CMake(self )
+        cmake = CMake(self, build_type = "Release")
         cmake.configure()
         cmake.build(target = "nicegraf_shaderc")
+
+    def package_id(self):
+        self.info.include_build_settings()
+        del self.info.settings.compiler
+        del self.info.settings.arch
 
     def package(self):
         if self.settings.os_build == "Windows":


### PR DESCRIPTION
+git shallow clone opt.