### PR TITLE
[1.6.1] Update to the latest niceshade, fix Linux & macos-x86_64 builds

### DIFF
--- a/.github/workflows/conan.yml
+++ b/.github/workflows/conan.yml
@@ -70,7 +70,7 @@ jobs:
         conan upload "niceshade" -r triada -c
 
   macos:
-    runs-on: macos-12
+    runs-on: macos-14
     steps:
     - uses: actions/checkout@v4
       with:

--- a/conanfile.py
+++ b/conanfile.py
@@ -5,7 +5,7 @@ import os
 
 class NiceshadeConan(ConanFile):
     name = "niceshade"
-    version = "1.6"
+    version = "1.6.1"
     license = "MIT"
     url = "https://github.com/triadastudio/conan-niceshade.git"
     homepage = "https://github.com/nicebyte/niceshade"
@@ -18,7 +18,7 @@ class NiceshadeConan(ConanFile):
 
     @property
     def _source_commit(self):
-        return "e9032116f60c3ae74ec7b6b75bad7945f443fabe"
+        return "c60c214c762a5e93d15e81260134056686256337"
 
     def configure(self):
         self.settings.rm_safe("compiler.cppstd")

--- a/profiles/linux.profile
+++ b/profiles/linux.profile
@@ -2,11 +2,11 @@
 os=Linux
 arch=x86_64
 compiler=clang
-compiler.version=13
+compiler.version=16
 compiler.libcxx=libstdc++11
 compiler.cppstd=20
 build_type=Release
 
 [buildenv]
-CC=/usr/bin/clang-13
-CXX=/usr/bin/clang++-13
+CC=/usr/bin/clang-16
+CXX=/usr/bin/clang++-16


### PR DESCRIPTION
Use cross compiling on macos (arm64) nodes to build x86_64 binaries
Update no longer available macos-12 nodes and use macos-14 in GitHub CI workflow
Upgrade to Clang-16 on Linux